### PR TITLE
Remove links to defunct sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ A minimal [Jekyll](https://jekyllrb.com/) site — no theme, no plugins, one lay
 
 - `index.md` — the page itself: Details, About, Experience loop, Links
 - `_jobs/` — one Markdown file per job, newest last by filename (`YYYY-MM-company.md`);
-  front matter carries `title`, `company`, `company_url`, `dates`
+  front matter carries `title`, `company`, `company_url`, `dates`, and optional
+  `company_prefix` — the word before the company name in the heading (default `at`)
 - `_data/projects.yml` — the projects listed in the header
 - `_layouts/default.html` — the single layout: head, header, footer
 - `styles.css` — screen, print and dark-mode styles in one file

--- a/_jobs/2012-09-freelance.md
+++ b/_jobs/2012-09-freelance.md
@@ -1,6 +1,7 @@
 ---
 title: Web Developer
 company: Freelance
+company_prefix: "—"
 dates: September 2012 — July 2013
 ---
 

--- a/_jobs/2013-07-amplifr.md
+++ b/_jobs/2013-07-amplifr.md
@@ -1,7 +1,6 @@
 ---
 title: Frontend Developer
 company: Amplifr
-company_url: https://amplifr.com
 dates: July 2013 — July 2015
 ---
 

--- a/index.md
+++ b/index.md
@@ -26,9 +26,8 @@ Beyond prototypes and MVPs, interface decisions should be driven by sufficient, 
 data. I rely on automated testing focused on critical paths and the places where
 problems actually appear, rather than on TDD for its own sake.
 
-I organized the St. Petersburg frontend community
-[spb.frontend()](https://spb-frontend.ru/) from its founding and hosted its
-[podcast](https://spb-frontend.ru/persons/akurganow), and later co-hosted
+I organized the St. Petersburg frontend community spb.frontend() from its founding
+and hosted its podcast, and later co-hosted
 [Ponaehali](https://ponaehali.fireside.fm), a podcast unrelated to programming.
 Outside of work: snowboarding and go-karting.
 
@@ -36,7 +35,7 @@ Outside of work: snowboarding and go-karting.
 
 {% for job in site.jobs reversed %}
 <article class="job">
-  <h3>{{ job.title }} <span class="job-company">{% if job.company_url %}at <a href="{{ job.company_url }}">{{ job.company }}</a>{% else %}— {{ job.company }}{% endif %}</span></h3>
+  <h3>{{ job.title }} <span class="job-company">{% if job.company_url %}at <a href="{{ job.company_url }}">{{ job.company }}</a>{% else %}{{ job.company_prefix | default: "at" }} {{ job.company }}{% endif %}</span></h3>
   <p class="job-dates">{{ job.dates }}</p>
   {{ job.content | markdownify }}
 </article>


### PR DESCRIPTION
Follow-up to #230. amplifr.com and spb-frontend.ru are dead (owner-confirmed):

- unlink the spb.frontend() community and podcast mentions in About (plain text now)
- drop `company_url` from the Amplifr job so the company renders as plain text
- the job template gains an optional `company_prefix` front matter key (default "at"), so Freelance keeps its "— Freelance" form

Verified with a local Jekyll 3.10 (github-pages gem) build — no Liquid leaks, headings render as "at Amplifr" / "— Freelance".

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyAWb22z3YNnGGRW5tSNQQ)_