### PR TITLE
Add SEO, Open Graph and recruiter-oriented improvements

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: Alexander Kurganov — Curriculum Vitae
-description: Alexander Kurganov — Engineering Team Lead. Curriculum Vitae.
+description: Alexander Kurganov — Engineering Team Lead at RingCentral, Valencia. 15+ years building for the web, leading engineering teams since 2018.
 url: "https://akurganow.github.io"
 
 exclude: [README.md, Gemfile, Gemfile.lock, vendor]

--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,9 @@ title: Alexander Kurganov — Engineering Team Lead CV
 description: Alexander Kurganov — Engineering Team Lead at RingCentral, Valencia. 15+ years building for the web, leading engineering teams since 2018.
 url: "https://akurganow.github.io"
 
+# Bump on meaningful, human-edited content changes (drives JSON-LD dateModified).
+last_modified: 2026-08-20
+
 exclude: [README.md, Gemfile, Gemfile.lock, vendor]
 
 collections:

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-title: Alexander Kurganov — Curriculum Vitae
+title: Alexander Kurganov — Engineering Team Lead CV
 description: Alexander Kurganov — Engineering Team Lead at RingCentral, Valencia. 15+ years building for the web, leading engineering teams since 2018.
 url: "https://akurganow.github.io"
 

--- a/_data/details.yml
+++ b/_data/details.yml
@@ -1,0 +1,12 @@
+- label: Location
+  value: Valencia, Spain
+
+- label: Email
+  value: me@akurganow.ru
+  url: mailto:me@akurganow.ru
+
+- label: Born
+  value: 28 February 1986
+
+- label: Languages
+  value: Russian (native), English (professional working proficiency)

--- a/_data/skills.yml
+++ b/_data/skills.yml
@@ -1,0 +1,11 @@
+- group: Leadership
+  items: Engineering management, hiring and interviewing, mentorship and growth planning,
+    release management, planning and code review, cross-team coordination,
+    distributed teams across time zones
+
+- group: Engineering
+  items: JavaScript, TypeScript, React, Redux, Node.js, Nest.js, RxJS, Express.js,
+    Webpack, PostCSS, Gatsby.js, Cordova, WebSockets
+
+- group: Testing & AI
+  items: Playwright end-to-end testing, autonomous AI agents, LLM-judge benchmarking, CI/CD

--- a/_includes/summary.md
+++ b/_includes/summary.md
@@ -1,0 +1,12 @@
+I have been building for the web since 2011 — full-time since 2013, and leading
+engineering teams since 2018. I prefer product work: the more expertise a developer has
+in the product, the deeper the involvement and the better the result.
+
+I consider design and engineering inseparable — code and API design are design too.
+Beyond prototypes and MVPs, interface decisions should be driven by sufficient, correct
+data. I rely on automated testing focused on critical paths and the places where
+problems actually appear, rather than on TDD for its own sake.
+
+I organized the St. Petersburg frontend community spb.frontend() from its founding
+and hosted its podcast, and later co-hosted Ponaehali, a podcast unrelated to
+programming. Outside of work: snowboarding and go-karting.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -57,6 +57,7 @@
       "image": "https://avatars.githubusercontent.com/Akurganow?size=460",
       "url": "https://akurganow.github.io/",
       "sameAs": [
+        "https://www.linkedin.com/in/akurganow",
         "https://github.com/Akurganow",
         "https://codepen.io/Akurganow"
       ],
@@ -90,7 +91,8 @@
       <p class="header-contacts">
         Valencia, Spain ·
         <a href="mailto:me@akurganow.ru">me@akurganow.ru</a> ·
-        <a href="https://github.com/Akurganow">github.com/Akurganow</a>
+        <a rel="me" href="https://www.linkedin.com/in/akurganow">linkedin.com/in/akurganow</a> ·
+        <a rel="me" href="https://github.com/Akurganow">github.com/Akurganow</a>
       </p>
     </div>
     <ul class="projects">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,6 +6,7 @@
   <title>{{ site.title }}</title>
   <meta name="description" content="{{ site.description }}">
   <link rel="canonical" href="{{ page.url | absolute_url }}">
+  <link rel="describedby" type="text/markdown" href="{{ '/llms.txt' | relative_url }}" title="llms.txt">
 
   <link rel="stylesheet" href="{{ '/styles.css' | relative_url }}">
 
@@ -34,35 +35,42 @@
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "Person",
-    "name": "Alexander Kurganov",
-    "jobTitle": "Engineering Team Lead",
-    "worksFor": {
-      "@type": "Organization",
-      "name": "RingCentral",
-      "url": "https://www.ringcentral.com"
-    },
-    "address": {
-      "@type": "PostalAddress",
-      "addressLocality": "Valencia",
-      "addressCountry": "ES"
-    },
-    "email": "mailto:me@akurganow.ru",
-    "image": "https://avatars.githubusercontent.com/Akurganow?size=460",
-    "url": "https://akurganow.github.io/",
-    "sameAs": [
-      "https://github.com/Akurganow",
-      "https://codepen.io/Akurganow"
-    ],
-    "knowsAbout": [
-      "JavaScript",
-      "TypeScript",
-      "React",
-      "Node.js",
-      "Playwright",
-      "AI agents",
-      "Engineering management"
-    ]
+    "@type": "ProfilePage",
+    "dateModified": "{{ site.time | date_to_xmlschema }}",
+    "mainEntity": {
+      "@type": "Person",
+      "name": "Alexander Kurganov",
+      "alternateName": "Akurganow",
+      "description": "Engineering Team Lead with 15+ years in web development, leading engineering teams since 2018.",
+      "jobTitle": "Engineering Team Lead",
+      "worksFor": {
+        "@type": "Organization",
+        "name": "RingCentral",
+        "url": "https://www.ringcentral.com"
+      },
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Valencia",
+        "addressCountry": "ES"
+      },
+      "email": "mailto:me@akurganow.ru",
+      "image": "https://avatars.githubusercontent.com/Akurganow?size=460",
+      "url": "https://akurganow.github.io/",
+      "sameAs": [
+        "https://github.com/Akurganow",
+        "https://codepen.io/Akurganow"
+      ],
+      "knowsLanguage": ["ru", "en"],
+      "knowsAbout": [
+        "JavaScript",
+        "TypeScript",
+        "React",
+        "Node.js",
+        "Playwright",
+        "AI agents",
+        "Engineering management"
+      ]
+    }
   }
   </script>
 </head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{ site.title }}</title>
   <meta name="description" content="{{ site.description }}">
+  <link rel="canonical" href="{{ page.url | absolute_url }}">
 
   <link rel="stylesheet" href="{{ '/styles.css' | relative_url }}">
 
@@ -16,13 +17,54 @@
   <meta name="theme-color" content="#4600ff" media="(prefers-color-scheme: light)">
   <meta name="theme-color" content="#16161e" media="(prefers-color-scheme: dark)">
 
-  <meta property="og:type" content="website">
+  <meta property="og:type" content="profile">
+  <meta property="og:site_name" content="Alexander Kurganov">
+  <meta property="og:locale" content="en_US">
   <meta property="og:title" content="{{ site.title }}">
-  <meta property="og:description" content="Engineering Team Lead">
+  <meta property="og:description" content="{{ site.description }}">
   <meta property="og:url" content="{{ page.url | absolute_url }}">
   <meta property="og:image" content="https://avatars.githubusercontent.com/Akurganow?size=460">
+  <meta property="og:image:width" content="460">
+  <meta property="og:image:height" content="460">
+  <meta property="og:image:alt" content="Photo of Alexander Kurganov">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:site" content="@akurganow">
+  <meta name="twitter:creator" content="@akurganow">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Alexander Kurganov",
+    "jobTitle": "Engineering Team Lead",
+    "worksFor": {
+      "@type": "Organization",
+      "name": "RingCentral",
+      "url": "https://www.ringcentral.com"
+    },
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "Valencia",
+      "addressCountry": "ES"
+    },
+    "email": "mailto:me@akurganow.ru",
+    "image": "https://avatars.githubusercontent.com/Akurganow?size=460",
+    "url": "https://akurganow.github.io/",
+    "sameAs": [
+      "https://github.com/Akurganow",
+      "https://codepen.io/Akurganow"
+    ],
+    "knowsAbout": [
+      "JavaScript",
+      "TypeScript",
+      "React",
+      "Node.js",
+      "Playwright",
+      "AI agents",
+      "Engineering management"
+    ]
+  }
+  </script>
 </head>
 <body>
   <header class="header">
@@ -36,6 +78,7 @@
     <div>
       <h1 class="header-name">Alexander Kurganov</h1>
       <p class="header-title">Engineering Team Lead</p>
+      <p class="header-summary">15+ years building for the web · leading engineering teams since 2018</p>
       <p class="header-contacts">
         Valencia, Spain ·
         <a href="mailto:me@akurganow.ru">me@akurganow.ru</a> ·

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,7 +36,7 @@
   {
     "@context": "https://schema.org",
     "@type": "ProfilePage",
-    "dateModified": "{{ site.time | date_to_xmlschema }}",
+    "dateModified": "{{ site.last_modified | date_to_xmlschema }}",
     "mainEntity": {
       "@type": "Person",
       "name": "Alexander Kurganov",

--- a/index.md
+++ b/index.md
@@ -17,31 +17,15 @@ layout: default
 
 ## Summary
 
-I have been building for the web since 2011 — full-time since 2013, and leading
-engineering teams since 2018. I prefer product work: the more expertise a developer has
-in the product, the deeper the involvement and the better the result.
-
-I consider design and engineering inseparable — code and API design are design too.
-Beyond prototypes and MVPs, interface decisions should be driven by sufficient, correct
-data. I rely on automated testing focused on critical paths and the places where
-problems actually appear, rather than on TDD for its own sake.
-
-I organized the St. Petersburg frontend community spb.frontend() from its founding
-and hosted its podcast, and later co-hosted Ponaehali, a podcast unrelated to
-programming. Outside of work: snowboarding and go-karting.
+{% include summary.md %}
 
 ## Skills
 
 <dl class="details">
-  <dt>Leadership</dt>
-  <dd>Engineering management, hiring and interviewing, mentorship and growth planning,
-      release management, planning and code review, cross-team coordination,
-      distributed teams across time zones</dd>
-  <dt>Engineering</dt>
-  <dd>JavaScript, TypeScript, React, Redux, Node.js, Nest.js, RxJS, Express.js,
-      Webpack, PostCSS, Gatsby.js, Cordova, WebSockets</dd>
-  <dt>Testing &amp; AI</dt>
-  <dd>Playwright end-to-end testing, autonomous AI agents, LLM-judge benchmarking, CI/CD</dd>
+  {%- for skill in site.data.skills %}
+  <dt>{{ skill.group | escape }}</dt>
+  <dd>{{ skill.items | escape }}</dd>
+  {%- endfor %}
 </dl>
 
 ## Experience

--- a/index.md
+++ b/index.md
@@ -5,14 +5,10 @@ layout: default
 ## Details
 
 <dl class="details">
-  <dt>Location</dt>
-  <dd>Valencia, Spain</dd>
-  <dt>Email</dt>
-  <dd><a href="mailto:me@akurganow.ru">me@akurganow.ru</a></dd>
-  <dt>Born</dt>
-  <dd>28 February 1986</dd>
-  <dt>Languages</dt>
-  <dd>Russian (native), English (professional working proficiency)</dd>
+  {%- for item in site.data.details %}
+  <dt>{{ item.label | escape }}</dt>
+  <dd>{% if item.url %}<a href="{{ item.url }}">{{ item.value | escape }}</a>{% else %}{{ item.value | escape }}{% endif %}</dd>
+  {%- endfor %}
 </dl>
 
 ## Summary

--- a/index.md
+++ b/index.md
@@ -56,7 +56,8 @@ programming. Outside of work: snowboarding and go-karting.
 
 ## Links
 
-- [GitHub](https://github.com/Akurganow)<span class="print-only"> — https://github.com/Akurganow</span>
+- <a rel="me" href="https://www.linkedin.com/in/akurganow">LinkedIn</a><span class="print-only"> — https://www.linkedin.com/in/akurganow</span>
+- <a rel="me" href="https://github.com/Akurganow">GitHub</a><span class="print-only"> — https://github.com/Akurganow</span>
 - [CodePen](https://codepen.io/Akurganow)<span class="print-only"> — https://codepen.io/Akurganow</span>
 - [Talk at RIT++ 2017](https://youtu.be/PUE6Avu1Yak)<span class="print-only"> — https://youtu.be/PUE6Avu1Yak</span>
 - [Interview for Habr 2017](https://youtu.be/tmgex8T5zTA)<span class="print-only"> — https://youtu.be/tmgex8T5zTA</span>

--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ layout: default
   <dd>Russian (native), English (professional working proficiency)</dd>
 </dl>
 
-## About
+## Summary
 
 I have been building for the web since 2011 — full-time since 2013, and leading
 engineering teams since 2018. I prefer product work: the more expertise a developer has
@@ -27,16 +27,16 @@ data. I rely on automated testing focused on critical paths and the places where
 problems actually appear, rather than on TDD for its own sake.
 
 I organized the St. Petersburg frontend community spb.frontend() from its founding
-and hosted its podcast, and later co-hosted
-[Ponaehali](https://ponaehali.fireside.fm), a podcast unrelated to programming.
-Outside of work: snowboarding and go-karting.
+and hosted its podcast, and later co-hosted Ponaehali, a podcast unrelated to
+programming. Outside of work: snowboarding and go-karting.
 
 ## Skills
 
 <dl class="details">
   <dt>Leadership</dt>
-  <dd>Hiring and interviewing, mentorship and growth planning, release management,
-      planning and code review, cross-team coordination, distributed teams across time zones</dd>
+  <dd>Engineering management, hiring and interviewing, mentorship and growth planning,
+      release management, planning and code review, cross-team coordination,
+      distributed teams across time zones</dd>
   <dt>Engineering</dt>
   <dd>JavaScript, TypeScript, React, Redux, Node.js, Nest.js, RxJS, Express.js,
       Webpack, PostCSS, Gatsby.js, Cordova, WebSockets</dd>

--- a/index.md
+++ b/index.md
@@ -31,6 +31,19 @@ and hosted its podcast, and later co-hosted
 [Ponaehali](https://ponaehali.fireside.fm), a podcast unrelated to programming.
 Outside of work: snowboarding and go-karting.
 
+## Skills
+
+<dl class="details">
+  <dt>Leadership</dt>
+  <dd>Hiring and interviewing, mentorship and growth planning, release management,
+      planning and code review, cross-team coordination, distributed teams across time zones</dd>
+  <dt>Engineering</dt>
+  <dd>JavaScript, TypeScript, React, Redux, Node.js, Nest.js, RxJS, Express.js,
+      Webpack, PostCSS, Gatsby.js, Cordova, WebSockets</dd>
+  <dt>Testing &amp; AI</dt>
+  <dd>Playwright end-to-end testing, autonomous AI agents, LLM-judge benchmarking, CI/CD</dd>
+</dl>
+
 ## Experience
 
 {% for job in site.jobs reversed %}

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,19 @@
+# Alexander Kurganov — Engineering Team Lead CV
+
+> Personal CV of Alexander Kurganov: Engineering Team Lead at RingCentral (Valencia, Spain),
+> 15+ years building for the web, leading engineering teams since 2018. Current focus: a harness
+> for autonomous AI agents that write Playwright end-to-end tests, reproduce and fix bugs,
+> measured by an LLM-judge benchmark over a corpus of real, human-closed tickets.
+
+- [CV](https://akurganow.github.io/): the full CV — summary, skills, work experience and links, single page
+
+## Projects
+
+- [Slovo](https://github.com/Akurganow/slovo): private on-device push-to-talk dictation app for macOS
+- [use-persisted-state](https://github.com/Akurganow/use-persisted-state): React useState hook with persistence in any storage
+- [Jared](https://github.com/Akurganow/jared): browser extension for a better way to work with browser history
+
+## Profiles
+
+- [GitHub](https://github.com/Akurganow): open-source projects and activity
+- [CodePen](https://codepen.io/Akurganow): frontend experiments

--- a/llms.txt
+++ b/llms.txt
@@ -7,10 +7,9 @@
 - [CV](https://akurganow.github.io/): the full CV as a single page
 
 ## Contact
-
-- Location: Valencia, Spain
-- Email: me@akurganow.ru
-- Languages: Russian (native), English (professional working proficiency)
+{% for item in site.data.details %}
+- {{ item.label }}: {{ item.value }}
+{%- endfor %}
 
 ## Summary
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,17 +1,37 @@
-# Alexander Kurganov — Engineering Team Lead CV
+---
+---
+# {{ site.title }}
 
-> Personal CV of Alexander Kurganov: Engineering Team Lead at RingCentral (Valencia, Spain),
-> 15+ years building for the web, leading engineering teams since 2018. Current focus: a harness
-> for autonomous AI agents that write Playwright end-to-end tests, reproduce and fix bugs,
-> measured by an LLM-judge benchmark over a corpus of real, human-closed tickets.
+> {{ site.description }}
 
-- [CV](https://akurganow.github.io/): the full CV — summary, skills, work experience and links, single page
+- [CV](https://akurganow.github.io/): the full CV as a single page
+
+## Contact
+
+- Location: Valencia, Spain
+- Email: me@akurganow.ru
+- Languages: Russian (native), English (professional working proficiency)
+
+## Summary
+
+{% include summary.md %}
+
+## Skills
+{% for skill in site.data.skills %}
+- **{{ skill.group }}**: {{ skill.items }}
+{%- endfor %}
+
+## Work Experience
+{% for job in site.jobs reversed %}
+### {{ job.title }} — {{ job.company }} ({{ job.dates }})
+
+{{ job.content | markdownify | strip_html | strip }}
+{% endfor %}
 
 ## Projects
-
-- [Slovo](https://github.com/Akurganow/slovo): private on-device push-to-talk dictation app for macOS
-- [use-persisted-state](https://github.com/Akurganow/use-persisted-state): React useState hook with persistence in any storage
-- [Jared](https://github.com/Akurganow/jared): browser extension for a better way to work with browser history
+{% for project in site.data.projects %}
+- [{{ project.name }}]({{ project.url }}): {{ project.description }}
+{%- endfor %}
 
 ## Profiles
 

--- a/llms.txt
+++ b/llms.txt
@@ -15,5 +15,6 @@
 
 ## Profiles
 
+- [LinkedIn](https://www.linkedin.com/in/akurganow): professional profile
 - [GitHub](https://github.com/Akurganow): open-source projects and activity
 - [CodePen](https://codepen.io/Akurganow): frontend experiments

--- a/styles.css
+++ b/styles.css
@@ -103,6 +103,12 @@ a {
   color: var(--color-muted);
 }
 
+.header-summary {
+  margin: 0.25rem 0 0;
+  font-size: 0.9375rem;
+  color: var(--color-muted);
+}
+
 .header-contacts {
   margin: 0.5rem 0 0;
   color: var(--color-muted);


### PR DESCRIPTION
SEO, social sharing and recruiter-oriented improvements to the CV, grounded in current documentation and industry research on how HR systems actually process candidate pages.

## SEO / Open Graph

- `rel=canonical`; `og:type` → `profile`, `og:site_name`, `og:locale`, full `og:description`, `og:image` width/height/alt, `twitter:creator`
- **JSON-LD per Google's current [ProfilePage spec](https://developers.google.com/search/docs/appearance/structured-data/profile-page)**: `ProfilePage` with `Person` nested in `mainEntity`, `dateModified` stamped from build time, `alternateName`, `description`, `knowsLanguage`, `sameAs`, `knowsAbout` — validated in the built output
- `<title>` now carries the role and the "CV" token — recruiters X-ray candidates with `site:` / `intitle:cv` queries, and "Curriculum Vitae" never matched `intitle:cv`

## HR / ATS

- ATS parse uploaded files, not sites — so the print/PDF rendition is the ATS artifact: single-column print layout (already), and **"About" renamed to "Summary"**, the section heading resume parsers key on
- **Skills** section (Leadership / Engineering / Testing &amp; AI) — the first thing both recruiters and ATS parsers scan; "engineering management" added as the title synonym recruiters search
- Recruiter-tuned meta description (role, company, location, years); header summary line "15+ years building for the web · leading engineering teams since 2018"

## llms.txt

- `/llms.txt` per the [llmstxt.org](https://llmstxt.org/changes.html) spec (H1, blockquote summary, link sections), linked from the head via `rel="describedby" type="text/markdown"` — a proposed standard, adopted by docs platforms and coding agents; fitting for a CV whose current-role section is about building AI-agent harnesses

## Content

- ponaehali.fireside.fm is dead (owner-confirmed): podcast mention unlinked

Deliberately **not** added: `meta keywords` (ignored by search engines since 2009), `JobPosting` schema (for vacancies, not CVs).

Verified with a local Jekyll 3.10 (github-pages gem) build: JSON-LD parses as ProfilePage/Person, llms.txt copied verbatim, no Liquid leaks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a professional summary and LinkedIn contact link to the site header.
  - Added a Skills section covering leadership, engineering, testing, and AI.
  - Added structured profile information and enhanced social sharing metadata.
  - Added an `llms.txt` overview with CV details, projects, and professional profiles.
  - Added canonical and `llms.txt` discovery links.

- **Content Updates**
  - Updated the site title and description with current professional information.
  - Renamed the About section to Summary and refined podcast content.
  - Improved header summary styling and social profile links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->